### PR TITLE
add service_ip host_ip to service metric

### DIFF
--- a/analyzer-common/src/main/java/cloud/erda/analyzer/common/constant/SpanConstants.java
+++ b/analyzer-common/src/main/java/cloud/erda/analyzer/common/constant/SpanConstants.java
@@ -78,6 +78,10 @@ public class SpanConstants {
 
     public static final String SERVICE_INSTANCE_ID = "service_instance_id";
 
+    public static final String HOST_IP = "host_ip";
+
+    public static final String SERVICE_IP = "service_ip";
+
     public static final String SERVICE_INSTANCE_STARTED_AT = "service_instance_started_at";
 
     public static final String PROJECT_NAME = "project_name";

--- a/analyzer-tracing/src/main/java/cloud/erda/analyzer/tracing/functions/SpanToServiceMetricFunction.java
+++ b/analyzer-tracing/src/main/java/cloud/erda/analyzer/tracing/functions/SpanToServiceMetricFunction.java
@@ -45,6 +45,9 @@ public class SpanToServiceMetricFunction implements MapFunction<Span, MetricEven
         metricEvent.addTag(SpanConstants.SERVICE_INSTANCE_IP, span.getAttributes().get(SpanConstants.SERVICE_INSTANCE_IP));
         metricEvent.addTag(SpanConstants.PROJECT_NAME, span.getAttributes().get(SpanConstants.PROJECT_NAME));
         metricEvent.addTag(SpanConstants.WORKSPACE, span.getAttributes().get(SpanConstants.WORKSPACE));
+        metricEvent.addTag(SpanConstants.HOST_IP, span.getAttributes().get(SpanConstants.HOST_IP));
+        metricEvent.addTag(SpanConstants.SERVICE_IP, span.getAttributes().get(SpanConstants.SERVICE_IP));
+
         int startTimeCount = 0;
         metricEvent.addField(SpanConstants.START_TIME_COUNT, startTimeCount);
         if (log.isDebugEnabled()) {


### PR DESCRIPTION
otlp span生成metric的时候带上host_ip,  service_ip的属性，使之可以关联service，host的监控指标

Otlp span brings host when generating metric_ ip, service_ IP attributes, which can be associated with the monitoring indicators of service and host
